### PR TITLE
Add alias command to list, add, update or remove user defined aliases for players

### DIFF
--- a/commands/alias.js
+++ b/commands/alias.js
@@ -53,6 +53,8 @@ module.exports = {
        * Add or update alias with args
        */
       if (aliases && aliases[alias]) {
+        aliases[alias] = commandArgs.join(" ");
+        player.setMeta("alias", aliases);
         return B.sayAt(player, `Alias '${alias}' updated!`);
       }
 

--- a/commands/alias.js
+++ b/commands/alias.js
@@ -1,0 +1,66 @@
+"use strict";
+
+const { Broadcast: B, Logger } = require("ranvier");
+const sprintf = require("sprintf-js").sprintf;
+
+module.exports = {
+  usage: "alias [word] [command]",
+  command: state => (args, player, arg0) => {
+    let aliases = player.getMeta("alias") || {};
+
+    args = args
+      .toString()
+      .trim()
+      .toLowerCase();
+    const [alias, ...commandArgs] = args.split(" ");
+
+    if (!alias && commandArgs.length === 0) {
+      /**
+       * prints defined alias list
+       */
+      B.sayAt(
+        player,
+        sprintf("<cyan>%-20s</cyan> | <cyan>%-57s</cyan>", "Alias", "Command")
+      );
+      B.sayAt(player, B.line(20) + "-+-" + B.line(57));
+
+      if (!aliases || Object.entries(aliases).length === 0) {
+        return B.sayAt(player, "No aliases defined yet!");
+      }
+
+      for (let [key, value] of Object.entries(aliases)) {
+        B.sayAt(player, sprintf("%-20s | %-57s", key, value));
+      }
+    }
+
+    if (alias && commandArgs.length === 0) {
+      /**
+       * drop alias
+       */
+      if (aliases && aliases[alias]) {
+        delete aliases[alias];
+        player.setMeta("alias", aliases);
+        player.save();
+
+        return B.sayAt(player, `Alias '${alias}' deleted!`);
+      }
+
+      return B.sayAt(player, `Alias '${alias}' not found!`);
+    }
+
+    if (alias && commandArgs.length > 0) {
+      /**
+       * Add or update alias with args
+       */
+      if (aliases && aliases[alias]) {
+        return B.sayAt(player, `Alias '${alias}' updated!`);
+      }
+
+      aliases[alias] = commandArgs.join(" ");
+      player.setMeta("alias", aliases);
+      player.save();
+
+      return B.sayAt(player, `Alias '${alias}' added!`);
+    }
+  }
+};

--- a/help/alias.yml
+++ b/help/alias.yml
@@ -1,0 +1,11 @@
+---
+command: alias
+body: |
+  Alias allows you to set shortcuts for commands or long strings of text.
+
+  - alias - print all defined aliases
+  - alias <word> - delete matching defined alias
+  - alias <word> <command> - define or update an alias
+
+keywords:
+- aliases

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "humanize-duration": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.14.0.tgz",
-      "integrity": "sha512-ebqI6Aaw64T7e7bZoFeoHkvlyy7mpVDqXCPm9gLFi9S42QWD3PWQ1FMwDKJo0y8/sXcfZ9hughSadLwTfmafmw=="
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.24.0.tgz",
+      "integrity": "sha512-B3udnqisaDeRsvUSb+5n2hjxhABI9jotB+i1IEhgHhguTeM5LxIUKoVIu7UpeyaPOygr/Fnv7UhOi45kYYG+tg=="
     }
   }
 }


### PR DESCRIPTION
This PR adds a sample alias command to list, add, update or remove user defined aliases for players, these alias are stored as 'alias' metadata on player file.

Note: This is only the alias definition doesn't call any command, requires, to work properly, a command parser integration to detect and call defined command.