### PR TITLE
Check actualCommand actually exists

### DIFF
--- a/commands/help.js
+++ b/commands/help.js
@@ -45,10 +45,12 @@ function render(state, hfile) {
   if (hfile.command) {
     let actualCommand = state.CommandManager.get(hfile.command);
 
-    header += formatHeaderItem('Syntax', actualCommand.usage);
+    if (actualCommand) {
+      header += formatHeaderItem('Syntax', actualCommand.usage);
 
-    if (actualCommand.aliases && actualCommand.aliases.length > 0){
-      header += formatHeaderItem('Aliases', actualCommand.aliases.join(', '));
+      if (actualCommand.aliases && actualCommand.aliases.length > 0){
+        header += formatHeaderItem('Aliases', actualCommand.aliases.join(', '));
+      }
     }
   } else if (hfile.channel) {
     header += formatHeaderItem('Syntax', state.ChannelManager.get(hfile.channel).getUsage());


### PR DESCRIPTION
In case a helpfile is found, but the command is not existing this errors out, when trying to render the `Syntax` and `Aliases` header.